### PR TITLE
verilator simulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,27 +313,18 @@ VER_SRC_V	:= $(VER_TB_VLOG) \
 			   $(TB_DIR)/spike_difftest.v \
 			   $(TB_DIR)/tty.v
 
-TB_DEFINE			:= +define+MODEL=$(STARSHIP_TH)					\
+VER_DEFINE			:= +define+MODEL=$(STARSHIP_TH)					\
 						+define+TOP_DIR=\"$(VER_BUILD)\"			\
 						+define+INITIALIZE_MEMORY					\
 						+define+CLOCK_PERIOD=1.0	   				\
 						+define+DEBUG_VCD							\
 						+define+TARGET_$(STARSHIP_CORE)
 
-CHISEL_DEFINE := +define+PRINTF_COND=$(VER_TB).printf_cond	\
-			   	 +define+STOP_COND=!$(VER_TB).reset		    \
-				 +define+RANDOMIZE							\
-				 +define+RANDOMIZE_MEM_INIT					\
-				 +define+RANDOMIZE_REG_INIT					\
-				 +define+RANDOMIZE_GARBAGE_ASSIGN			\
-				 +define+RANDOMIZE_INVALID_ASSIGN			\
-				 +define+RANDOMIZE_DELAY=0.1
-
 VER_TOP		:= $(VER_TB)
 VER_SRCS 		:= $(shell cat $(ROCKET_INCLUDE)) $(VER_SRC_V) $(VER_SRC_C)
 VER_TFLAGS	:= -Wno-WIDTH -Wno-STMTDLY -Wno-fatal --timescale 1ns/10ps --trace --timing
 VER_OPTION	:= +systemverilogext+.sva+.pkg+.sv+.SV+.vh+.svh+.svi+ 			\
-			   			+incdir+$(ROCKET_BUILD) +incdir+$(TB_DIR) $(CHISEL_DEFINE) $(TB_DEFINE)
+			   			+incdir+$(ROCKET_BUILD) +incdir+$(TB_DIR) $(CHISEL_DEFINE) $(VER_DEFINE)
 VER_FLAGS		:= --cc --exe --Mdir $(VER_BUILD) --top-module $(VER_TOP) --main -o $(VER_TOP) \
 						-CFLAGS "-DVL_DEBUG -DTOP=${VER_TOP} ${VCS_CFLAGS}"
 
@@ -348,7 +339,8 @@ $(VER_TARGET):$(VERILOG_SRC) $(ROCKET_ROM_HEX) $(ROCKET_INCLUDE) $(VER_SRC_V) $(
 	cd $(VER_BUILD); verilator $(VER_TFLAGS) $(VER_FLAGS) $(VER_OPTION) $(VER_SRCS)
 	make -C $(VER_BUILD) -f V$(VER_TOP).mk $(VER_TOP)
 	
-verilate: $(VER_TARGET) $(TESTCASE_HEX)
+verilate: 
+	# $(VER_TARGET) $(TESTCASE_HEX)
 	cd $(VER_BUILD); ./$(VER_TOP) $(VER_SIMOPTION)
 
 wave:

--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,78 @@ verdi:
 		-ssf $(VCS_WAVE)/starship.fsdb -sswr $(VERDI_OUTPUT)/signal.rc \
 		-logfile $(VCS_LOG)/verdi.log -top $(VCS_TB) -f $(ROCKET_INCLUDE) $(VCS_SRC_V) &
 
+#######################################
+#
+#            Verilator
+#
+#######################################
+
+TB_DIR		:= $(ASIC)/testbench
+VER_BUILD	:= $(BUILD)/verilate
+VER_WAVE 	:= $(VER_BUILD)/wave
+VER_TARGET  := $(VER_BUILD)/$(VER_TOP)
+
+VER_TB		?= Testbench
+VER_INCLUDE	:= $(ROCKET_BUILD)+$(TB_DIR)
+VER_CFLAGS	:= -std=c++17 $(addprefix -I,$(SPIKE_INCLUDE)) -I$(ROCKET_BUILD)
+VER_TB_VLOG ?= $(TB_DIR)/$(VER_TB).v
+
+TESTCASE_ELF	:= $(STARSHIP_TESTCASE)
+TESTCASE_BIN	:= $(shell mktemp)
+TESTCASE_HEX	:= $(STARSHIP_TESTCASE).hex
+
+VER_SRC_C	:= $(TB_DIR)/spike_difftest.cc \
+			   $(SPIKE_LIB) \
+			   $(TB_DIR)/timer.cc
+
+VER_SRC_V	:= $(VER_TB_VLOG) \
+			   $(TB_DIR)/spike_difftest.v \
+			   $(TB_DIR)/tty.v
+
+TB_DEFINE			:= +define+MODEL=$(STARSHIP_TH)					\
+						+define+TOP_DIR=\"$(VER_BUILD)\"			\
+						+define+INITIALIZE_MEMORY					\
+						+define+CLOCK_PERIOD=1.0	   				\
+						+define+DEBUG_VCD							\
+						+define+TARGET_$(STARSHIP_CORE)
+
+CHISEL_DEFINE := +define+PRINTF_COND=$(VER_TB).printf_cond	\
+			   	 +define+STOP_COND=!$(VER_TB).reset		    \
+				 +define+RANDOMIZE							\
+				 +define+RANDOMIZE_MEM_INIT					\
+				 +define+RANDOMIZE_REG_INIT					\
+				 +define+RANDOMIZE_GARBAGE_ASSIGN			\
+				 +define+RANDOMIZE_INVALID_ASSIGN			\
+				 +define+RANDOMIZE_DELAY=0.1
+
+VER_TOP		:= $(VER_TB)
+VER_SRCS 		:= $(shell cat $(ROCKET_INCLUDE)) $(VER_SRC_V) $(VER_SRC_C)
+VER_TFLAGS	:= -Wno-WIDTH -Wno-STMTDLY -Wno-fatal --timescale 1ns/10ps --trace --timing
+VER_OPTION	:= +systemverilogext+.sva+.pkg+.sv+.SV+.vh+.svh+.svi+ 			\
+			   			+incdir+$(ROCKET_BUILD) +incdir+$(TB_DIR) $(CHISEL_DEFINE) $(TB_DEFINE)
+VER_FLAGS		:= --cc --exe --Mdir $(VER_BUILD) --top-module $(VER_TOP) --main -o $(VER_TOP) \
+						-CFLAGS "-DVL_DEBUG -DTOP=${VER_TOP} ${VCS_CFLAGS}"
+
+ver-wave: 		VER_SIMOPTION	:= +testcase=$(TESTCASE_ELF) 
+ver-jtag: 		VER_SIMOPTION	:= +testcase=$(TESTCASE_ELF) +jtag_rbb_enable=1
+ver-jtag-debug: VER_SIMOPTION	:= +testcase=$(TESTCASE_ELF) +dump +jtag_rbb_enable=1
+
+$(VER_TARGET):$(VERILOG_SRC) $(ROCKET_ROM_HEX) $(ROCKET_INCLUDE) $(VER_SRC_V) $(VER_SRC_C) $(SPIKE_LIB) 
+	$(MAKE) verilog-patch
+	mkdir -p $(VER_BUILD)
+	mkdir -p $(VER_BUILD)/wave/
+	cd $(VER_BUILD); verilator $(VER_TFLAGS) $(VER_FLAGS) $(VER_OPTION) $(VER_SRCS)
+	make -C $(VER_BUILD) -f V$(VER_TOP).mk $(VER_TOP)
+	
+verilate: $(VER_TARGET) $(TESTCASE_HEX)
+	cd $(VER_BUILD); ./$(VER_TOP) $(VER_SIMOPTION)
+
+wave:
+	gtkwave $(VER_WAVE)/starship.vcd
+
+ver-wave: 		verilate
+ver-jtag: 		verilate
+ver-jtag-debug: verilate
 
 #######################################
 #

--- a/Makefile
+++ b/Makefile
@@ -337,7 +337,7 @@ VER_OPTION	:= +systemverilogext+.sva+.pkg+.sv+.SV+.vh+.svh+.svi+ 			\
 VER_FLAGS		:= --cc --exe --Mdir $(VER_BUILD) --top-module $(VER_TOP) --main -o $(VER_TOP) \
 						-CFLAGS "-DVL_DEBUG -DTOP=${VER_TOP} ${VCS_CFLAGS}"
 
-ver-wave: 		VER_SIMOPTION	:= +testcase=$(TESTCASE_ELF) 
+ver-wave: 		VER_SIMOPTION	:= +testcase=$(TESTCASE_ELF) +dump 
 ver-jtag: 		VER_SIMOPTION	:= +testcase=$(TESTCASE_ELF) +jtag_rbb_enable=1
 ver-jtag-debug: VER_SIMOPTION	:= +testcase=$(TESTCASE_ELF) +dump +jtag_rbb_enable=1
 

--- a/asic/testbench/Testbench.v
+++ b/asic/testbench/Testbench.v
@@ -43,11 +43,15 @@ module Testbench;
   always #(`CLOCK_PERIOD/2.0) clock = ~clock;
   initial #(`RESET_DELAY) reset = 0;
 
-  assign `SOC_TOP.metaReset = reset;
+  `ifdef VCS
+    assign `SOC_TOP.metaReset = reset;
+  `endif
 
   initial begin
     $system("echo -e \"\033[31m[>] vcs start `date +%s.%3N` \033[0m\"");
-    force `PIPELINE.io_interrupts_msip = interrupt;
+    `ifdef VCS
+      force `PIPELINE.io_interrupts_msip = interrupt;
+    `endif
   end 
 
   int unsigned rand_value;
@@ -59,6 +63,7 @@ module Testbench;
   reg verbose = 1'b0;
   reg fuzz = 1'b0;
   reg dump_wave = 1'b0;
+  reg jtag_rbb_enable = 1'b0;
   reg [63:0] max_cycles = 0;
   reg [63:0] dump_start = 0;
   reg [63:0] trace_count = 0;
@@ -73,6 +78,7 @@ module Testbench;
   initial begin
     void'($value$plusargs("max-cycles=%d", max_cycles));
     void'($value$plusargs("dump-start=%d", dump_start));
+    void'($value$plusargs("jtag_rbb_enable=%d", jtag_rbb_enable));
     verbose = $test$plusargs("verbose");
     fuzz = $test$plusargs("fuzzing");
     dump_wave = $test$plusargs("dump");
@@ -84,7 +90,9 @@ module Testbench;
     rand_value = $urandom;
     rand_value = $random(rand_value);
     if (verbose) begin
-      $fdisplay(32'h80000002, "testing $random %0x seed %d", rand_value, unsigned'($get_initial_random_seed));
+      `ifdef VCS
+        $fdisplay(32'h80000002, "testing $random %0x seed %d", rand_value, unsigned'($get_initial_random_seed));
+      `endif
     end
 
     if (dump_wave) begin
@@ -122,52 +130,54 @@ module Testbench;
   end
 
   always @(negedge clock) begin
-    trace_count = trace_count + 1;
-    if (trace_count == dump_start) begin
-      if (dump_wave) begin
-        `WAVE_ON
-      end
-    end
-
-    if (!reset) begin
-      if (max_cycles > 0 && trace_count > max_cycles) begin
-        reason = " (timeout)";
-        failure = 1'b1;
-      end
-
-      if (failure) begin
-        $fdisplay(32'h80000002, "*** FAILED ***%s after %d simulation cycles", reason, trace_count);
-        trace_count = 0;
-        failure = 0;
-        if (fuzz) begin
-          $system("echo -e \"\033[31m[>] round timeout `date +%s.%3N` \033[0m\"");
-          cosim_set_tohost(5);
-          fuzz_manager();
-        end else begin
-          if (dump_wave) begin
-            `WAVE_CLOSE
-          end
-          $fatal;
+    if(!jtag_rbb_enable)begin
+      trace_count = trace_count + 1;
+      if (trace_count == dump_start) begin
+        if (dump_wave) begin
+          `WAVE_ON
         end
       end
-      if (tohost & 1'b1) begin
-        $fdisplay(32'h80000002, "*** PASSED *** Completed after %d simulation cycles", trace_count);
-        trace_count = 0;
-        if (fuzz) begin
-          $system("echo -e \"\033[31m[>] round finish `date +%s.%3N` \033[0m\"");
-          fuzz_manager();
-        end else begin
-          if (dump_wave) begin
-            `WAVE_CLOSE
-          end
-          $system("echo -e \"\033[31m[>] vcs stop `date +%s.%3N` \033[0m\"");
-          timer_result = timer_stop();
-          $display("Finish time: %d ns", timer_result);
-          $display("[CJ] coverage sum = %d", Testbench.testHarness.ldut.io_covSum);
-          // $writememh("test.hex", Testbench.testHarness.ldut.tile_prci_domain.tile_reset_domain_tile.frontend.tlb.r_need_gpa);
-          $finish;
+
+      if (!reset) begin
+        if (max_cycles > 0 && trace_count > max_cycles) begin
+          reason = " (timeout)";
+          failure = 1'b1;
         end
 
+        if (failure) begin
+          $fdisplay(32'h80000002, "*** FAILED ***%s after %d simulation cycles", reason, trace_count);
+          trace_count = 0;
+          failure = 0;
+          if (fuzz) begin
+            $system("echo -e \"\033[31m[>] round timeout `date +%s.%3N` \033[0m\"");
+            cosim_set_tohost(5);
+            fuzz_manager();
+          end else begin
+            if (dump_wave) begin
+              `WAVE_CLOSE
+            end
+            $fatal;
+          end
+        end
+        if (tohost & 1'b1) begin
+          $fdisplay(32'h80000002, "*** PASSED *** Completed after %d simulation cycles", trace_count);
+          trace_count = 0;
+          if (fuzz) begin
+            $system("echo -e \"\033[31m[>] round finish `date +%s.%3N` \033[0m\"");
+            fuzz_manager();
+          end else begin
+            if (dump_wave) begin
+              `WAVE_CLOSE
+            end
+            $system("echo -e \"\033[31m[>] vcs stop `date +%s.%3N` \033[0m\"");
+            timer_result = timer_stop();
+            $display("Finish time: %d ns", timer_result);
+            $display("[CJ] coverage sum = %d", Testbench.testHarness.ldut.io_covSum);
+            // $writememh("test.hex", Testbench.testHarness.ldut.tile_prci_domain.tile_reset_domain_tile.frontend.tlb.r_need_gpa);
+            $finish;
+          end
+
+        end
       end
     end
   end
@@ -175,7 +185,7 @@ module Testbench;
   TestHarness testHarness(
     .clock(clock),
     .reset(reset),
-    .io_uart_tx(1'b0),
+    .io_uart_tx(),
     .io_uart_rx(1'b0)
   // .io_uart_tx(uart_tx),
   // .io_uart_rx(uart_rx)

--- a/asic/testbench/Testbench.v
+++ b/asic/testbench/Testbench.v
@@ -193,7 +193,7 @@ module Testbench;
 
   CJ rtlfuzz (
     .clock(clock),
-    .reset(reset),
+    .reset(reset|jtag_rbb_enable),
     .tohost(tohost));
 
   // tty #(115200, 0) u0_tty(

--- a/asic/testbench/spike_difftest.v
+++ b/asic/testbench/spike_difftest.v
@@ -22,7 +22,7 @@ import "DPI-C" function void cosim_init(
 
 import "DPI-C" function longint cosim_get_tohost();
 
-import "DPI-C" function void cosim_set_tohost(input longint unsigned value);
+// import "DPI-C" function void cosim_set_tohost(input longint unsigned value);
 
 module CJ #(parameter harts=1, commits=2) (
     input clock,

--- a/asic/verilator_tool/spike.cfg
+++ b/asic/verilator_tool/spike.cfg
@@ -1,0 +1,19 @@
+adapter_khz     1000
+
+interface remote_bitbang
+remote_bitbang_host localhost
+remote_bitbang_port 9824
+
+set _CHIPNAME riscv
+jtag newtap $_CHIPNAME cpu -irlen 5
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos hwthread
+
+riscv set_reset_timeout_sec 120
+riscv set_command_timeout_sec 120
+# riscv set_prefer_sba oon
+
+init
+halt
+echo "Ready for Remote Connections"

--- a/repo/starship/src/main/scala/asic/SimTop.scala
+++ b/repo/starship/src/main/scala/asic/SimTop.scala
@@ -39,6 +39,7 @@ class StarshipSimTopModuleImp[+L <: StarshipSimTop](_outer: L) extends StarshipS
 
 
 class TestHarness()(implicit p: Parameters) extends Module {
+  
   val io = IO(new Bundle {
     val uart_tx = Output(Bool())
     val uart_rx = Input(Bool())

--- a/repo/starship/src/main/scala/fpga/Configs.scala
+++ b/repo/starship/src/main/scala/fpga/Configs.scala
@@ -46,3 +46,19 @@ class StarshipFPGAConfig extends Config(
       x.copy(master = x.master.copy(size = site(VCU707DDRSizeKey))))
   })
 )
+
+class StarshipFPGADebugConfig extends Config(
+  new WithPeripherals ++
+  new WithJtagDTM ++
+  new WithClockGateModel() ++
+  new StarshipBaseConfig().alter((site,here,up) => {
+    //case DebugModuleKey => None
+    case PeripheryBusKey => up(PeripheryBusKey, site).copy(dtsFrequency = Some(site(FrequencyKey).toInt * 1000000))
+    /* timebase-frequency = 1 MHz */
+    case DTSTimebase => BigInt(1000000L)
+    /* memory-size = 1 GB */
+    case MemoryXilinxDDRKey => XilinxVC707MIGParams(address = Seq(AddressSet(0x80000000L,site(VCU707DDRSizeKey)-1)))
+    case ExtMem => up(ExtMem, site).map(x => 
+      x.copy(master = x.master.copy(size = site(VCU707DDRSizeKey))))
+  })
+)


### PR DESCRIPTION
in order to simulate the rocket-chip with verilator, I comment two un-compatible codes in the testbench.v and add a verilator segment in the Makefile. VER_FLAGS with --main can let verilator to generate a driver main function automatically and can handler the delay in verilog grammar.